### PR TITLE
Unlocking mutex in success case too

### DIFF
--- a/src/video/SDL_pixels.c
+++ b/src/video/SDL_pixels.c
@@ -661,6 +661,7 @@ const SDL_PixelFormatDetails *SDL_GetPixelFormatDetails(SDL_PixelFormat format)
     }
 
     if (SDL_FindInHashTable(SDL_format_details, (const void *)(uintptr_t)format, (const void **)&details)) {
+        SDL_UnlockMutex(SDL_format_details_lock);
         return details;
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix Mutex Unlock in SDL_GetPixelFormatDetails: without unlocking, we trigger an assertion failure in SDL_sysmutex.c at line 80 (i.e. 'rc == 0'). Each lock-unlock pair should ideally cancel each other out, maintaining a reference count that returns to zero.

## Description
<!--- Describe your changes in detail -->
Added missing SDL_UnlockMutex call before returning from SDL_GetPixelFormatDetails to ensure the mutex is properly released, preventing assertion failures in SDL_sysmutex.c at line 80 due to unbalanced mutex lock-unlock operations.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
N/A - This change addresses assertion failures and a potential defect where mutexes could remain locked under certain conditions, leading to resource leaks and stability issues.

Platform details:
MacBook Pro: 2021 M1 
Xcode: Version 15.4 (15F31d)
macOS: 14.5 (23F79)
Libraries: SDL3 (7277d69c0e4deee2c1a6e70a5822087fbaa2a944) and SDL_ttf (99468fc2a7d0ba8a62c91f79f7a47c711ae21814)